### PR TITLE
feat: extra tweaks & additions to eels-e-r 2.

### DIFF
--- a/.github/actions/build-evm-base/action.yaml
+++ b/.github/actions/build-evm-base/action.yaml
@@ -46,6 +46,7 @@ runs:
         echo "X-Dist parameter: ${{ steps.config-evm-impl-config-reader.outputs.x-dist }}"
     - name: Skip building for EELS
       if: steps.config-evm-reader.outputs.impl == 'eels'
+      shell: bash
       run: echo "Skipping build for EELS"
     - name: Build the EVM using Geth action
       if: steps.config-evm-reader.outputs.impl == 'geth'

--- a/.github/actions/build-evm-base/action.yaml
+++ b/.github/actions/build-evm-base/action.yaml
@@ -44,6 +44,9 @@ runs:
         echo "Reference: ${{ steps.config-evm-reader.outputs.ref }}"
         echo "EVM Binary: ${{ steps.config-evm-impl-config-reader.outputs.evm-bin }}"
         echo "X-Dist parameter: ${{ steps.config-evm-impl-config-reader.outputs.x-dist }}"
+    - name: Skip building for EELS
+      if: steps.config-evm-reader.outputs.impl == 'eels'
+      run: echo "Skipping build for EELS"
     - name: Build the EVM using Geth action
       if: steps.config-evm-reader.outputs.impl == 'geth'
       uses: ./.github/actions/build-evm-client/geth

--- a/.github/configs/evm-impl.yaml
+++ b/.github/configs/evm-impl.yaml
@@ -1,3 +1,6 @@
+eels:
+  evm-bin: ethereum-spec-evm-resolver
+  x-dist: auto
 geth:
   evm-bin: evm
   x-dist: auto

--- a/.github/configs/evm.yaml
+++ b/.github/configs/evm.yaml
@@ -1,7 +1,7 @@
 stable:
-  impl: geth
-  repo: ethereum/go-ethereum
-  ref: master
+  impl: eels
+  repo: null
+  ref: null
 develop:
   impl: geth
   repo: lightclient/go-ethereum

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,7 +40,7 @@ Test fixtures for use by clients are available for each release on the [Github r
 
 ### 🔧 EVM Tools
 
-- ✨ Use the `ethereum-specs` evm resolver tool to fill tests, which provides a speed increase of around 57x in comparison to geth ([#453](https://github.com/ethereum/execution-spec-tests/pull/453)).
+- ✨ Use the `ethereum-specs` evm resolver tool to fill tests, which provides a speed increase of around 57x in comparison to geth ([#792](https://github.com/ethereum/execution-spec-tests/pull/792)).
 
 ### 📋 Misc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "click>=8.1.0,<9",
     "ethereum @ git+https://github.com/ethereum/execution-specs",
     "hive.py @ git+https://github.com/marioevz/hive.py",
+    "ethereum-spec-evm-resolver @ git+https://github.com/petertdavies/ethereum-spec-evm-resolver",
     "setuptools",
     "types-setuptools",
     "gitpython>=3.1.31,<4",

--- a/src/evm_transition_tool/execution_specs.py
+++ b/src/evm_transition_tool/execution_specs.py
@@ -24,7 +24,7 @@ class ExecutionSpecsTransitionTool(TransitionTool):
 
     `ethereum-spec-evm-resolver` is installed by default for `execution-spec-tests`:
     ```console
-    uv run fill --evm-bin=ethereum-spec-evm
+    uv run fill --evm-bin=ethereum-spec-evm-resolver
     ```
 
     To use a specific version of the `ethereum-spec-evm-resolver` tool, update it to the
@@ -56,7 +56,7 @@ class ExecutionSpecsTransitionTool(TransitionTool):
                 f"{e}."
             )
         except Exception as e:
-            raise Exception(f"Unexpected exception calling ethereum-spec-evm: {e}.")
+            raise Exception(f"Unexpected exception calling ethereum-spec-evm-resolver: {e}.")
         self.help_string = result.stdout
 
     def start_server(self):

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -423,7 +423,7 @@ class TransitionTool(FixtureVerifier):
                 },
             )
 
-        response = Session().post(self.server_url, json=post_data, timeout=120)
+        response = Session().post(self.server_url, json=post_data, timeout=20)
         response.raise_for_status()  # exception visible in pytest failure output
         if response.status_code != 200:
             raise Exception(

--- a/src/evm_transition_tool/transition_tool.py
+++ b/src/evm_transition_tool/transition_tool.py
@@ -423,7 +423,7 @@ class TransitionTool(FixtureVerifier):
                 },
             )
 
-        response = Session().post(self.server_url, json=post_data, timeout=10)
+        response = Session().post(self.server_url, json=post_data, timeout=120)
         response.raise_for_status()  # exception visible in pytest failure output
         if response.status_code != 200:
             raise Exception(

--- a/src/pytest_plugins/filler/filler.py
+++ b/src/pytest_plugins/filler/filler.py
@@ -80,9 +80,9 @@ def pytest_addoption(parser: pytest.Parser):
         action="store",
         dest="evm_bin",
         type=Path,
-        default=None,
+        default=".venv/bin/ethereum-spec-evm-resolver",
         help=(
-            "Path to an evm executable that provides `t8n`. Default: First 'evm' entry in PATH."
+            "Path to an evm executable that provides `t8n`. Default: Ethereum-Spec-EVM-Resolver."
         ),
     )
     evm_group.addoption(

--- a/uv.lock
+++ b/uv.lock
@@ -548,6 +548,7 @@ dependencies = [
     { name = "coincurve" },
     { name = "colorlog" },
     { name = "ethereum" },
+    { name = "ethereum-spec-evm-resolver" },
     { name = "filelock" },
     { name = "gitpython" },
     { name = "hive-py" },
@@ -558,6 +559,7 @@ dependencies = [
     { name = "pytest-metadata" },
     { name = "pytest-xdist" },
     { name = "requests" },
+    { name = "requests-unixsocket2" },
     { name = "rich" },
     { name = "semver" },
     { name = "setuptools" },
@@ -607,6 +609,7 @@ requires-dist = [
     { name = "coincurve", specifier = ">=20.0.0,<21" },
     { name = "colorlog", specifier = ">=6.7.0,<7" },
     { name = "ethereum", git = "https://github.com/ethereum/execution-specs" },
+    { name = "ethereum-spec-evm-resolver", git = "https://github.com/petertdavies/ethereum-spec-evm-resolver" },
     { name = "filelock", specifier = ">=3.15.1,<4" },
     { name = "flake8", marker = "extra == 'lint'", specifier = ">=6.1.0,<7" },
     { name = "flake8-docstrings", marker = "extra == 'lint'", specifier = ">=1.6,<2" },
@@ -637,6 +640,7 @@ requires-dist = [
     { name = "pytest-metadata", specifier = ">=3,<4" },
     { name = "pytest-xdist", specifier = ">=3.3.1,<4" },
     { name = "requests", specifier = ">=2.31.0,<3" },
+    { name = "requests-unixsocket2", specifier = ">=0.4.0" },
     { name = "rich", specifier = ">=13.7.0,<14" },
     { name = "semver", specifier = ">=3.0.1,<4" },
     { name = "setuptools" },
@@ -645,6 +649,22 @@ requires-dist = [
     { name = "trie", specifier = ">=2.0.2,<3" },
     { name = "types-requests", marker = "extra == 'lint'" },
     { name = "types-setuptools" },
+]
+
+[[package]]
+name = "ethereum-spec-evm-resolver"
+version = "0.0.5"
+source = { git = "https://github.com/petertdavies/ethereum-spec-evm-resolver#ab1c732b1b7a8ecf2c3ff3bc73fce45ba7a7d00b" }
+dependencies = [
+    { name = "coincurve" },
+    { name = "eth2spec" },
+    { name = "filelock" },
+    { name = "gitpython" },
+    { name = "platformdirs" },
+    { name = "pycryptodome" },
+    { name = "requests-unixsocket2" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
 ]
 
 [[package]]
@@ -1857,6 +1877,19 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-unixsocket2"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/fc/23d7312a1d210b6b6e39a2193c2b2e8262ea4ccfb54a297a76a01ab795c6/requests_unixsocket2-0.4.0.tar.gz", hash = "sha256:06d0bb51551a8552e7ce67937a3e19c5516f62b97ccd412b17e94a0b4c4980b9", size = 6363 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/3a/60c77c2cea5b11609179cc6a172179d6ae900826b42438848255c43e38e0/requests_unixsocket2-0.4.0-py3-none-any.whl", hash = "sha256:8d3cafcc7b2feb18f85b0a5e37e4ff7b1a64777000ebd1a883df33012a07f16f", size = 7944 },
+]
+
+[[package]]
 name = "rich"
 version = "13.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2058,14 +2091,14 @@ wheels = [
 
 [[package]]
 name = "types-requests"
-version = "2.32.0.20240712"
+version = "2.31.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "urllib3" },
+    { name = "types-urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/9e/7663eb27c33568b8fc20ccdaf2a1ce53a9530c42a7cceb9f552a6ff4a1d8/types-requests-2.32.0.20240712.tar.gz", hash = "sha256:90c079ff05e549f6bf50e02e910210b98b8ff1ebdd18e19c873cd237737c1358", size = 17896 }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/b8/c1e8d39996b4929b918aba10dba5de07a8b3f4c8487bb61bb79882544e69/types-requests-2.31.0.6.tar.gz", hash = "sha256:cd74ce3b53c461f1228a9b783929ac73a666658f223e28ed29753771477b3bd0", size = 15535 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/4d/cbed87a6912fbd9259ce23a5d4aa1de9816edf75eec6ed9a757c00906c8e/types_requests-2.32.0.20240712-py3-none-any.whl", hash = "sha256:f754283e152c752e46e70942fa2a146b5bc70393522257bb85bd1ef7e019dcc3", size = 15816 },
+    { url = "https://files.pythonhosted.org/packages/5c/a1/6f8dc74d9069e790d604ddae70cb46dcbac668f1bb08136e7b0f2f5cd3bf/types_requests-2.31.0.6-py3-none-any.whl", hash = "sha256:a2db9cb228a81da8348b49ad6db3f5519452dd20a9c1e1a868c83c5fe88fd1a9", size = 14516 },
 ]
 
 [[package]]
@@ -2075,6 +2108,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/a8/5b26af1117daf328f3420fce5ad36f9331a2bbc689862923789402eb83d6/types-setuptools-73.0.0.20240822.tar.gz", hash = "sha256:3a060681098eb3fbc2fea0a86f7f6af6aa1ca71906039d88d891ea2cecdd4dbf", size = 42177 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/76/ec2cf632452154ecceaed2075707ca09719238e8ba53b3027f47ba78b90c/types_setuptools-73.0.0.20240822-py3-none-any.whl", hash = "sha256:b9eba9b68546031317a0fa506d4973641d987d74f79e7dd8369ad4f7a93dea17", size = 67135 },
+]
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/de/b9d7a68ad39092368fb21dd6194b362b98a1daeea5dcfef5e1adb5031c7e/types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f", size = 11239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e", size = 15377 },
 ]
 
 [[package]]
@@ -2088,11 +2130,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.2.2"
+version = "1.26.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/6d/fa469ae21497ddc8bc93e5877702dca7cb8f911e337aca7452b5724f1bb6/urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168", size = 292266 }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/1c/89ffc63a9605b583d5df2be791a27bc1a42b7c32bab68d3c8f2f73a98cd4/urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472", size = 121444 },
+    { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225 },
 ]
 
 [[package]]


### PR DESCRIPTION
Small tweaks:
1) Set the eels evm resolver to the default filling tool (no need to use `--evm-bin`).
2) Add eels evm resolver as a dependency, updating `uv.lock`.
3) Use eels evm resolver for stable fixture releases in ci.
